### PR TITLE
Temporary solution to avoid breaking the server

### DIFF
--- a/modules/evees/src/graphql/helpers.ts
+++ b/modules/evees/src/graphql/helpers.ts
@@ -213,7 +213,7 @@ export class EveesHelpers {
     const timestamp =
       commit.timestamp !== undefined ? commit.timestamp : Date.now();
     const creatorsIds =
-      commit.creatorsIds !== undefined ? commit.creatorsIds : [];
+      commit.creatorsIds !== undefined ? commit.creatorsIds : [''];
     const parentsIds = commit.parentsIds !== undefined ? commit.parentsIds : [];
 
     const commitData: Commit = {


### PR DESCRIPTION
So, basically this is the reason why this code was breaking in the backend: https://github.com/uprtcl/js-uprtcl-server/commit/a7b233d25217f8df162dbf53420dfe2a0b00df37 

When pages are being created commits are being sent without a creator, so the mapping function in the backend won't be able to loop through anything and will break. Instead, I added a small temporary change to avoid breaking the backend, but I think we should consider to get the user ID, before creating the commit and send it without a creator, as we do with the method `createPerspective`, that checks inside the perspective data if any creator is attached, otherwise, it will query the remote to find out who is creating the perspective, here is an example of the solution I am proposing for further development:

```
const remotes = container.getAll(EveesBindings.EveesRemote);
const remoteInstance: EveesRemote = remotes.find(
     (instance) => instance.id === remote
);

path = path !== undefined ? path : remoteInstance.defaultPath;

 creatorId =
   creatorId !== undefined
     ? creatorId
     : remoteInstance.userId !== undefined
    ? remoteInstance.userId
     : '';
```

We would need to send and integrate the remote as a parameter to the `createCommit` function.

So, let me know what you guys think, and if you think that the way I want to try to approach the problem is viable enough.